### PR TITLE
Upgrade ugettext_lazy 

### DIFF
--- a/zinnia/apps.py
+++ b/zinnia/apps.py
@@ -1,7 +1,7 @@
 """Apps for Zinnia"""
 from __future__ import absolute_import
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ZinniaConfig(AppConfig):


### PR DESCRIPTION
ugettext_lazy has been removed from Django 3+ version, Replace it with gettext_lazy.