### PR TITLE
Upgrade coverage from 4.4 to 7.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cffi==1.9.1
 chardet==2.3.0
 cobble==0.1.1
 constantly==15.1.0
-coverage==4.4
+coverage==7.8.0
 cryptography==1.7.1
 cssselect==0.9.2
 daphne==1.3.0


### PR DESCRIPTION
Upgrade coverage from 4.4 to 7.8.0: #9 
Requires python 3.9+