### PR TITLE
upgrade from pypdf2 1.2.6 to pypdf 5.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The key features for this user type include the following
 * PyJWT
 * PyMySQL
 * pyPdf
-* PyPDF2
+* ~PyPDF2~
 * python-dateutil
 * python-openid
 * python-social-auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,8 +87,7 @@ PyJWT==1.4.2
 PyMySQL==0.7.6
 pyOpenSSL==16.2.0
 pyparsing==2.1.10
-pyPdf==1.13
-PyPDF2==1.26.0
+pypdf==5.5.0
 pyproject_hooks==1.2.0
 pyquery==2.0.1
 pyth==0.6.0

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import mammoth
 import docx
-import PyPDF2
+from pypdf import PdfReader
 import json
 from datetime import datetime
 from django.db.models import Count
@@ -74,14 +74,14 @@ def get_pdf_content(pdf_path, page_nums=[]):
     content = ''
     try:
         p = open(pdf_path, "rb")
-        pdf = PyPDF2.PdfFileReader(p)
+        pdf = PdfReader(p)
         if page_nums:
-            for page_num in page_nums:
-                content += pdf.getPage(page_num).extractText() + '\n'
+            for page_num in range(len(pdf.pages)):
+                content += pdf.pages[page_num].extract_text() or '' + '\n'
             # print(content)
         else:
-            for page_num in range(0, pdf.getNumPages()):
-                content += pdf.getPage(page_num).extractText() + '\n'
+            for page_num in page_nums:
+                content += pdf.pages[page_num].extract_text() or '' + '\n'
             # print(content)
     except: 
         pass


### PR DESCRIPTION
upgrade from pypdf2 1.2.6 to pypdf 5.5.0
issue #7 
removed pypdf 2 from requirements as it is no longer required and updated the existing entry of pypdf to the latest version