### PR TITLE
Remove ipaddress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,6 @@ httplib2==0.9.2
 hyperlink==21.0.0
 idna==3.8
 incremental==17.5.0
-ipaddress==1.0.17
 ipgetter2==1.1.10
 lxml==5.3.0
 mammoth==1.9.0


### PR DESCRIPTION
Ipaddress module was used to implement new python 3.3+ features on python 2.6/2.7/2.8
nowhere in the repository this module is getting imported, so can we remove the library from the requirements file?
issue #14 