### PR TITLE
Drf completed for candidates

### DIFF
--- a/TRM/urls.py
+++ b/TRM/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     url(r'^api/common/', include('common.api.urls')),
     url(r'^api/activities/',include('activities.api.urls')),
     url(r'^api/vacancy/', include('vacancies_api.urls')),
+    url(r'^api/candidates/', include('candidates.api.urls')),
 
     # Resources
     url(r'resources/comments/', include('django_comments.urls')),

--- a/candidates/api/serializers.py
+++ b/candidates/api/serializers.py
@@ -1,0 +1,62 @@
+from rest_framework import serializers
+from candidates.models import (
+    Candidate, Expertise, Academic, CV_Language,
+    Training, Certificate, Project, Curriculum
+)
+
+# Candidate Serializer
+class CandidateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Candidate
+        fields = '__all__'
+
+
+# Expertise Serializer
+class ExpertiseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Expertise
+        fields = '__all__'
+
+
+# Academic Serializer
+class AcademicSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Academic
+        fields = '__all__'
+
+
+# CV Language Serializer
+class CVLanguageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CV_Language
+        fields = '__all__'
+
+
+# Training Serializer
+class TrainingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Training
+        fields = '__all__'
+
+
+# Certificate Serializer
+class CertificateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Certificate
+        fields = '__all__'
+
+
+# Project Serializer
+class ProjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        fields = '__all__'
+
+
+# Curriculum Serializer
+class CurriculumSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Curriculum
+        fields = '__all__'
+
+

--- a/candidates/api/urls.py
+++ b/candidates/api/urls.py
@@ -1,0 +1,18 @@
+from rest_framework.routers import DefaultRouter
+from candidates.views import (
+    CandidateViewSet, ExpertiseViewSet, AcademicViewSet,
+    CVLanguageViewSet, TrainingViewSet, CertificateViewSet,
+    ProjectViewSet, CurriculumViewSet
+)
+
+router = DefaultRouter()
+router.register(r'candidates', CandidateViewSet)
+router.register(r'expertises', ExpertiseViewSet)
+router.register(r'academics', AcademicViewSet)
+router.register(r'languages', CVLanguageViewSet)
+router.register(r'trainings', TrainingViewSet)
+router.register(r'certificates', CertificateViewSet)
+router.register(r'projects', ProjectViewSet)
+router.register(r'curriculums', CurriculumViewSet)
+
+urlpatterns = router.urls

--- a/candidates/api/views.py
+++ b/candidates/api/views.py
@@ -1,0 +1,51 @@
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from candidates.models import (
+    Candidate, Expertise, Academic, CV_Language,
+    Training, Certificate, Project, Curriculum
+)
+from candidates.serializers import (
+    CandidateSerializer, ExpertiseSerializer, AcademicSerializer, 
+    CVLanguageSerializer, TrainingSerializer, CertificateSerializer, 
+    ProjectSerializer, CurriculumSerializer
+)
+
+class CandidateViewSet(viewsets.ModelViewSet):
+    queryset = Candidate.objects.all()
+    serializer_class = CandidateSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class ExpertiseViewSet(viewsets.ModelViewSet):
+    queryset = Expertise.objects.all()
+    serializer_class = ExpertiseSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class AcademicViewSet(viewsets.ModelViewSet):
+    queryset = Academic.objects.all()
+    serializer_class = AcademicSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class CVLanguageViewSet(viewsets.ModelViewSet):
+    queryset = CV_Language.objects.all()
+    serializer_class = CVLanguageSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class TrainingViewSet(viewsets.ModelViewSet):
+    queryset = Training.objects.all()
+    serializer_class = TrainingSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class CertificateViewSet(viewsets.ModelViewSet):
+    queryset = Certificate.objects.all()
+    serializer_class = CertificateSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class ProjectViewSet(viewsets.ModelViewSet):
+    queryset = Project.objects.all()
+    serializer_class = ProjectSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class CurriculumViewSet(viewsets.ModelViewSet):
+    queryset = Curriculum.objects.all()
+    serializer_class = CurriculumSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]


### PR DESCRIPTION
1. Added DRF serializers and viewsets for all core models in the candidates module.
2. Exposed endpoints under /api/candidates/ using DefaultRouter.
3. Supports full CRUD operations for Candidate, Expertise, Academic, Language, Training, Certificate, Project, and Curriculum models.