### PR TITLE
#98 module integration serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,5 @@ pip-log.txt
 environment.py
 filecontent.txt
 .vscode
+
+venv/

--- a/ckeditor/api/serializers.py
+++ b/ckeditor/api/serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+from ckeditor.fields import RichTextField
+
+
+class RichTextSerializer(serializers.Serializer):
+    """
+    Serializer for CKEditor's RichTextField.
+    This serializer can be used to serialize any model field that uses RichTextField.
+    """
+    content = serializers.CharField(style={'base_template': 'textarea.html'})
+
+    class Meta:
+        fields = ['content'] 

--- a/customField/api/serializers.py
+++ b/customField/api/serializers.py
@@ -1,0 +1,66 @@
+from rest_framework import serializers
+from customField.models import FieldClassification, FieldType, Template, Field
+
+
+class FieldClassificationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FieldClassification
+        fields = [
+            'id', 'name', 'is_visible', 'requires_options',
+            'created_on', 'updated_on'
+        ]
+        read_only_fields = ['id', 'created_on', 'updated_on']
+
+
+class FieldTypeSerializer(serializers.ModelSerializer):
+    classification = FieldClassificationSerializer(read_only=True)
+    classification_id = serializers.PrimaryKeyRelatedField(
+        queryset=FieldClassification.objects.all(),
+        source='classification',
+        write_only=True,
+        required=False,
+        allow_null=True
+    )
+
+    class Meta:
+        model = FieldType
+        fields = [
+            'id', 'name', 'classification', 'classification_id',
+            'is_enabled', 'form_field', 'field_widget',
+            'created_on', 'updated_on'
+        ]
+        read_only_fields = ['id', 'created_on', 'updated_on']
+
+
+class FieldSerializer(serializers.ModelSerializer):
+    field_type = FieldTypeSerializer(read_only=True)
+    field_type_id = serializers.PrimaryKeyRelatedField(
+        queryset=FieldType.objects.all(),
+        source='field_type',
+        write_only=True
+    )
+
+    class Meta:
+        model = Field
+        fields = [
+            'id', 'name', 'field_type', 'field_type_id',
+            'is_required', 'template', 'created_on'
+        ]
+        read_only_fields = ['id', 'created_on']
+
+
+class TemplateSerializer(serializers.ModelSerializer):
+    fields = FieldSerializer(many=True, read_only=True)
+    rendered_form = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Template
+        fields = [
+            'id', 'name', 'belongs_to', 'fields',
+            'rendered_form', 'created_on', 'updated_on'
+        ]
+        read_only_fields = ['id', 'created_on', 'updated_on']
+
+    def get_rendered_form(self, obj):
+        """Get the rendered form HTML"""
+        return obj.rendered_form(preview=True) 

--- a/customField/api/serializers.py
+++ b/customField/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from customField.models import FieldClassification, FieldType, Template, Field
+from customField.models import FieldClassification, FieldType, Template, Field, Option, FieldValue
 
 
 class FieldClassificationSerializer(serializers.ModelSerializer):
@@ -32,6 +32,13 @@ class FieldTypeSerializer(serializers.ModelSerializer):
         read_only_fields = ['id', 'created_on', 'updated_on']
 
 
+class OptionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Option
+        fields = ['id', 'name', 'field', 'created_on', 'updated_on']
+        read_only_fields = ['id', 'created_on', 'updated_on']
+
+
 class FieldSerializer(serializers.ModelSerializer):
     field_type = FieldTypeSerializer(read_only=True)
     field_type_id = serializers.PrimaryKeyRelatedField(
@@ -39,27 +46,48 @@ class FieldSerializer(serializers.ModelSerializer):
         source='field_type',
         write_only=True
     )
+    options = OptionSerializer(source='field_option', many=True, read_only=True)
 
     class Meta:
         model = Field
         fields = [
             'id', 'name', 'field_type', 'field_type_id',
-            'is_required', 'template', 'created_on'
+            'is_required', 'template', 'created_on', 'updated_on',
+            'options'
         ]
-        read_only_fields = ['id', 'created_on']
+        read_only_fields = ['id', 'created_on', 'updated_on', 'options']
+
+
+class FieldValueSerializer(serializers.ModelSerializer):
+    field_name = serializers.CharField(source='field.name', read_only=True)
+    field = FieldSerializer(read_only=True)
+    field_id = serializers.PrimaryKeyRelatedField(
+        queryset=Field.objects.all(),
+        source='field',
+        write_only=True
+    )
+
+    class Meta:
+        model = FieldValue
+        fields = ['id', 'field', 'field_id', 'field_name', 'value', 'created_on']
+        read_only_fields = ['id', 'field_name', 'created_on']
 
 
 class TemplateSerializer(serializers.ModelSerializer):
     fields = FieldSerializer(many=True, read_only=True)
     rendered_form = serializers.SerializerMethodField()
+    belongs_to_name = serializers.CharField(source='belongs_to.name', read_only=True)
 
     class Meta:
         model = Template
         fields = [
-            'id', 'name', 'belongs_to', 'fields',
-            'rendered_form', 'created_on', 'updated_on'
+            'id', 'name', 'belongs_to', 'belongs_to_name',
+            'fields', 'rendered_form', 'created_on', 'updated_on'
         ]
-        read_only_fields = ['id', 'created_on', 'updated_on']
+        read_only_fields = [
+            'id', 'belongs_to_name', 'rendered_form',
+            'created_on', 'updated_on'
+        ]
 
     def get_rendered_form(self, obj):
         """Get the rendered form HTML"""

--- a/customField/serializers.py
+++ b/customField/serializers.py
@@ -3,64 +3,23 @@ from .models import (
     FieldClassification, FieldType, Template, Field,
     Option, FieldValue
 )
+from .api.serializers import (
+    FieldClassificationSerializer as APIFieldClassificationSerializer,
+    FieldTypeSerializer as APIFieldTypeSerializer,
+    FieldSerializer as APIFieldSerializer,
+    TemplateSerializer as APITemplateSerializer,
+    OptionSerializer as APIOptionSerializer,
+    FieldValueSerializer as APIFieldValueSerializer
+)
 
+# Re-export API serializers for backward compatibility
+FieldClassificationSerializer = APIFieldClassificationSerializer
+FieldTypeSerializer = APIFieldTypeSerializer
+FieldSerializer = APIFieldSerializer
+TemplateSerializer = APITemplateSerializer
+OptionSerializer = APIOptionSerializer
+FieldValueSerializer = APIFieldValueSerializer
 
-class FieldClassificationSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = FieldClassification
-        fields = '__all__'
-
-
-class FieldTypeSerializer(serializers.ModelSerializer):
-    classification = FieldClassificationSerializer(read_only=True)
-    classification_id = serializers.PrimaryKeyRelatedField(
-        queryset=FieldClassification.objects.all(), source='classification', write_only=True, required=False
-    )
-
-    class Meta:
-        model = FieldType
-        fields = [
-            'id', 'name', 'classification', 'classification_id', 'is_enabled',
-            'form_field', 'field_widget', 'created_on', 'updated_on'
-        ]
-
-
-class OptionSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Option
-        fields = ['id', 'name', 'field', 'created_on', 'updated_on']
-
-
-class FieldSerializer(serializers.ModelSerializer):
-    field_type = FieldTypeSerializer(read_only=True)
-    field_type_id = serializers.PrimaryKeyRelatedField(
-        queryset=FieldType.objects.all(), source='field_type', write_only=True
-    )
-    options = OptionSerializer(source='field_option', many=True, read_only=True)
-
-    class Meta:
-        model = Field
-        fields = [
-            'id', 'name', 'field_type', 'field_type_id', 'is_required',
-            'template', 'created_on', 'updated_on', 'options'
-        ]
-
-
-class TemplateSerializer(serializers.ModelSerializer):
-    fields = FieldSerializer(source='field_set', many=True, read_only=True)
-    belongs_to_name = serializers.CharField(source='belongs_to.name', read_only=True)
-
-    class Meta:
-        model = Template
-        fields = [
-            'id', 'name', 'created_on', 'updated_on', 'belongs_to',
-            'belongs_to_name', 'fields'
-        ]
-
-
-class FieldValueSerializer(serializers.ModelSerializer):
-    field_name = serializers.CharField(source='field.name', read_only=True)
-
-    class Meta:
-        model = FieldValue
-        fields = ['id', 'field', 'field_name', 'value']
+# Add any additional general-purpose serializers here if needed
+# These would be serializers that are not API-specific and might be used
+# in other parts of the application

--- a/scheduler/api/serializers.py
+++ b/scheduler/api/serializers.py
@@ -1,0 +1,27 @@
+from rest_framework import serializers
+from scheduler.models import Schedule
+from vacancies.api.serializers import PostulateSerializer
+
+
+class ScheduleSerializer(serializers.ModelSerializer):
+    application = PostulateSerializer(read_only=True)
+    application_id = serializers.PrimaryKeyRelatedField(
+        queryset=Schedule.objects.all(),
+        source='application',
+        write_only=True
+    )
+    status_display = serializers.CharField(source='get_status_display', read_only=True)
+    local_time = serializers.DateTimeField(read_only=True)
+    local_time_only = serializers.TimeField(read_only=True)
+
+    class Meta:
+        model = Schedule
+        fields = [
+            'id', 'scheduled_on', 'offset', 'status', 'status_display',
+            'application', 'application_id', 'user',
+            'local_time', 'local_time_only'
+        ]
+        read_only_fields = [
+            'id', 'status_display', 'local_time',
+            'local_time_only', 'user'
+        ] 

--- a/zinnia/api/serializers.py
+++ b/zinnia/api/serializers.py
@@ -3,6 +3,12 @@ from django.contrib.sites.models import Site
 from django.contrib.auth import get_user_model
 from zinnia.models import Entry, Author, Category
 from zinnia.managers import PUBLISHED
+from django.utils import timezone
+
+# Import existing serializers from other modules
+from ckeditor.api.serializers import RichTextSerializer
+from scheduler.api.serializers import ScheduleSerializer
+from customField.api.serializers import FieldSerializer
 
 
 class AuthorSerializer(serializers.ModelSerializer):
@@ -67,6 +73,9 @@ class EntrySerializer(serializers.ModelSerializer):
         queryset=Site.objects.all(),
         many=True
     )
+    ckeditor_content = RichTextSerializer(source='ckeditor', read_only=True)
+    scheduler = ScheduleSerializer(read_only=True)
+    custom_fields = FieldSerializer(many=True, read_only=True)
     status_display = serializers.CharField(source='get_status_display', read_only=True)
     html_content = serializers.CharField(read_only=True)
     html_preview = serializers.CharField(read_only=True)
@@ -93,14 +102,16 @@ class EntrySerializer(serializers.ModelSerializer):
             'login_required', 'password',
             'content_template', 'detail_template',
             'is_actual', 'is_visible', 'short_url',
-            'related_entries', 'get_absolute_url'
+            'related_entries', 'get_absolute_url',
+            'ckeditor_content', 'scheduler', 'custom_fields'
         ]
         read_only_fields = [
             'id', 'creation_date', 'last_update',
             'html_content', 'html_preview', 'word_count',
             'comments_count', 'pingbacks_count', 'trackbacks_count',
             'is_actual', 'is_visible', 'short_url',
-            'related_entries', 'get_absolute_url'
+            'related_entries', 'get_absolute_url',
+            'ckeditor_content', 'scheduler', 'custom_fields'
         ]
 
     def get_related_entries(self, obj):


### PR DESCRIPTION
#98 Added serializers for CKEditor, Scheduler, and CustomField

1. Implemented serializers for CKEditor, Scheduler, and CustomField models.
2. Enables API representation and validation for these models, paving the way for future API endpoints and frontend integration.