### PR TITLE
#112 lru cache import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ local.properties
 .settings/
 .loadpath
 
+venv/
+env/
+
 # External tool builders
 .externalToolBuilders/
 

--- a/zinnia/flags.py
+++ b/zinnia/flags.py
@@ -1,7 +1,7 @@
 """Comment flags for Zinnia"""
 from __future__ import absolute_import
 from django.contrib.auth import get_user_model
-from django.utils.lru_cache import lru_cache
+from functools import lru_cache
 
 from zinnia.settings import COMMENT_FLAG_USER_ID
 


### PR DESCRIPTION
#112 

Update lru_cache import to use standard library

Changed the deprecated `django.utils.lru_cache` import to use Python's standard library `functools.lru_cache` in `zinnia/flags.py`. 

Changes:
- Updated import statement in zinnia/flags.py
- No functional changes to the caching behavior
- No other files required updates as this was the only usage of the deprecated import