### PR TITLE
#109 remove python2 unicode imports and decorator declarations

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -15,7 +15,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _, gettext 
-from django.utils.encoding import python_2_unicode_compatible
 
 try:
     from django.utils import timezone
@@ -23,7 +22,6 @@ except ImportError:
     from datetime import datetime as timezone
 
 
-@python_2_unicode_compatible
 class Queue(models.Model):
     """
     A queue is a collection of tickets into what would generally be business
@@ -645,7 +643,6 @@ class FollowUpManager(models.Manager):
         return self.filter(public=True)
 
 
-@python_2_unicode_compatible
 class FollowUp(models.Model):
     """
     A FollowUp is a comment and/or change to a ticket. We keep a simple
@@ -737,7 +734,6 @@ class FollowUp(models.Model):
         super(FollowUp, self).save(*args, **kwargs)
 
 
-@python_2_unicode_compatible
 class TicketChange(models.Model):
     """
     Tracks changes to a ticket's fields associated with a follow-up.
@@ -812,7 +808,6 @@ def attachment_path(instance, filename):
     return os.path.join(path, filename)
 
 
-@python_2_unicode_compatible
 class Attachment(models.Model):
     """
     Represents a file attached to a follow-up. This could come from an e-mail
@@ -866,7 +861,6 @@ class Attachment(models.Model):
         verbose_name_plural = _('Attachments')
 
 
-@python_2_unicode_compatible
 class PreSetReply(models.Model):
     """
     We can allow the admin to define a number of pre-set replies, used to
@@ -914,7 +908,6 @@ class PreSetReply(models.Model):
         return '%s' % self.name
 
 
-@python_2_unicode_compatible
 class EscalationExclusion(models.Model):
     """
     An 'EscalationExclusion' lets us define a date on which escalation should
@@ -952,7 +945,6 @@ class EscalationExclusion(models.Model):
         verbose_name_plural = _('Escalation exclusions')
 
 
-@python_2_unicode_compatible
 class EmailTemplate(models.Model):
     """
     Since these are more likely to be changed than other templates, we store
@@ -1015,7 +1007,6 @@ class EmailTemplate(models.Model):
         verbose_name_plural = _('e-mail templates')
 
 
-@python_2_unicode_compatible
 class KBCategory(models.Model):
     """
     Lets help users help themselves: the Knowledge Base is a categorised
@@ -1049,7 +1040,6 @@ class KBCategory(models.Model):
     get_absolute_url = models.permalink(get_absolute_url)
 
 
-@python_2_unicode_compatible
 class KBItem(models.Model):
     """
     An item within the knowledgebase. Very straightforward question/answer
@@ -1127,7 +1117,6 @@ class KBItem(models.Model):
     get_absolute_url = models.permalink(get_absolute_url)
 
 
-@python_2_unicode_compatible
 class SavedSearch(models.Model):
     """
     Allow a user to save a ticket search, eg their filtering and sorting
@@ -1175,7 +1164,6 @@ class SavedSearch(models.Model):
         verbose_name_plural = _('Saved searches')
 
 
-@python_2_unicode_compatible
 class UserSettings(models.Model):
     """
     A bunch of user-specific settings that we want to be able to define, such
@@ -1246,7 +1234,6 @@ def create_usersettings(sender, instance, created, **kwargs):
 models.signals.post_save.connect(create_usersettings, sender=settings.AUTH_USER_MODEL)
 
 
-@python_2_unicode_compatible
 class IgnoreEmail(models.Model):
     """
     This model lets us easily ignore e-mails from certain senders when
@@ -1325,7 +1312,6 @@ class IgnoreEmail(models.Model):
             return False
 
 
-@python_2_unicode_compatible
 class TicketCC(models.Model):
     """
     Often, there are people who wish to follow a ticket who aren't the
@@ -1404,7 +1390,6 @@ class CustomFieldManager(models.Manager):
         return super(CustomFieldManager, self).get_queryset().order_by('ordering')
 
 
-@python_2_unicode_compatible
 class CustomField(models.Model):
     """
     Definitions for custom fields that are glued onto each ticket.
@@ -1525,7 +1510,6 @@ class CustomField(models.Model):
         verbose_name_plural = _('Custom fields')
 
 
-@python_2_unicode_compatible
 class TicketCustomFieldValue(models.Model):
     """
     Stores the value of a custom field for a specific ticket.
@@ -1556,7 +1540,6 @@ class TicketCustomFieldValue(models.Model):
         verbose_name_plural = _('Ticket custom field values')
 
 
-@python_2_unicode_compatible
 class TicketDependency(models.Model):
     """
     The ticket identified by `ticket` cannot be resolved until the ticket in `depends_on` has been resolved.

--- a/zinnia/models/author.py
+++ b/zinnia/models/author.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.apps import apps
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 
 from zinnia.managers import EntryRelatedPublishedManager
 from zinnia.managers import entries_published
@@ -28,7 +28,6 @@ class AuthorPublishedManager(models.Model):
         abstract = True
 
 
-@python_2_unicode_compatible
 class Author(safe_get_user_model(),
              AuthorPublishedManager):
     """

--- a/zinnia/models/category.py
+++ b/zinnia/models/category.py
@@ -1,7 +1,6 @@
 """Category model for Zinnia"""
 from __future__ import absolute_import
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import gettext_lazy as _
 
 from mptt.managers import TreeManager
@@ -12,8 +11,7 @@ from zinnia.managers import EntryRelatedPublishedManager
 from zinnia.managers import entries_published
 
 
-@python_2_unicode_compatible
-class Category(MPTTModel):
+class Category(models.Model):
     """
     Simple model for categorizing entries.
     """

--- a/zinnia/models/category.py
+++ b/zinnia/models/category.py
@@ -11,7 +11,7 @@ from zinnia.managers import EntryRelatedPublishedManager
 from zinnia.managers import entries_published
 
 
-class Category(models.Model):
+class Category(MPTTModel):
     """
     Simple model for categorizing entries.
     """

--- a/zinnia/models_bases/entry.py
+++ b/zinnia/models_bases/entry.py
@@ -34,7 +34,6 @@ from zinnia.settings import UPLOAD_TO
 from zinnia.url_shortener import get_url_shortener
 
 
-@python_2_unicode_compatible
 class CoreEntry(models.Model):
     """
     Abstract core entry model class providing

--- a/zinnia/preview.py
+++ b/zinnia/preview.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from bs4 import BeautifulSoup
 
 from django.utils import six
-from django.utils.encoding import python_2_unicode_compatible
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.html import strip_tags
 from django.utils.text import Truncator
@@ -15,7 +15,6 @@ from zinnia.settings import PREVIEW_MORE_STRING
 from zinnia.settings import PREVIEW_SPLITTERS
 
 
-@python_2_unicode_compatible
 class HTMLPreview(object):
     """
     Build an HTML preview of an HTML content.

--- a/zinnia/preview.py
+++ b/zinnia/preview.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from bs4 import BeautifulSoup
 
 from django.utils import six
-from django.utils.encoding import force_str
+
 from django.utils.functional import cached_property
 from django.utils.html import strip_tags
 from django.utils.text import Truncator


### PR DESCRIPTION
#109 
## Description
This PR removes all `@python_2_unicode_compatible` decorators and their imports from the codebase. These decorators were previously used to ensure compatibility between Python 2 and Python 3 string handling, but are no longer needed since Python 2 is no longer supported.

## Changes Made
- Removed `python_2_unicode_compatible` imports from:
  - `zinnia/preview.py`
  - `zinnia/models/category.py`
  - `zinnia/models_bases/entry.py`
  - `zinnia/models/author.py`
  - `helpdesk/models.py`
- Removed all `@python_2_unicode_compatible` decorators from class definitions
- Cleaned up related imports where necessary

## Impact
- No functional changes to the codebase