### PR TITLE
[fix] Remove deprecated models.permalink usage (#110)

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -13,6 +13,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
+from django.urls import reverse
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _, gettext 
 from django.utils.encoding import python_2_unicode_compatible
@@ -574,8 +575,7 @@ class Ticket(models.Model):
         return '%s %s' % (self.id, self.title)
 
     def get_absolute_url(self):
-        return 'helpdesk_view', (self.id,)
-    get_absolute_url = models.permalink(get_absolute_url)
+        return reverse('helpdesk_view', args=[self.id])
 
     def save(self, *args, **kwargs):
         """
@@ -1045,8 +1045,7 @@ class KBCategory(models.Model):
 
     def get_absolute_url(self):
         """Returns the URL path to view this knowledge base category."""
-        return 'helpdesk_kb_category', (), {'slug': self.slug}
-    get_absolute_url = models.permalink(get_absolute_url)
+        return reverse('helpdesk_kb_category', kwargs={'slug': self.slug})
 
 
 @python_2_unicode_compatible
@@ -1123,8 +1122,7 @@ class KBItem(models.Model):
 
     def get_absolute_url(self):
         """Returns the URL path to view this knowledge base item."""
-        return 'helpdesk_kb_item', (self.id,)
-    get_absolute_url = models.permalink(get_absolute_url)
+        return reverse('helpdesk_kb_item', args=[self.id])
 
 
 @python_2_unicode_compatible

--- a/zinnia/models/author.py
+++ b/zinnia/models/author.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django.apps import apps
 from django.conf import settings
 from django.db import models
+from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
 
 from zinnia.managers import EntryRelatedPublishedManager
@@ -41,12 +42,11 @@ class Author(safe_get_user_model(),
         """
         return entries_published(self.entries)
 
-    @models.permalink
     def get_absolute_url(self):
         """
         Builds and returns the author's URL based on his username.
         """
-        return ('zinnia:author_detail', [self.get_username()])
+        return reverse('zinnia:author_detail', args=[self.get_username()])
 
     def __str__(self):
         """

--- a/zinnia/models/category.py
+++ b/zinnia/models/category.py
@@ -1,6 +1,7 @@
 """Category model for Zinnia"""
 from __future__ import absolute_import
 from django.db import models
+from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import gettext_lazy as _
 
@@ -56,13 +57,12 @@ class Category(MPTTModel):
                 [self.slug])
         return self.slug
 
-    @models.permalink
     def get_absolute_url(self):
         """
         Builds and returns the category's URL
         based on his tree path.
         """
-        return ('zinnia:category_detail', (self.tree_path,))
+        return reverse('zinnia:category_detail', args=[self.tree_path])
 
     def __str__(self):
         return self.title

--- a/zinnia/models_bases/entry.py
+++ b/zinnia/models_bases/entry.py
@@ -4,6 +4,7 @@ import os
 
 from django.contrib.sites.models import Site
 from django.db import models
+from django.urls import reverse
 from django.db.models import Q
 from django.template.defaultfilters import slugify
 from django.utils import timezone
@@ -167,7 +168,6 @@ class CoreEntry(models.Model):
         self.last_update = timezone.now()
         super(CoreEntry, self).save(*args, **kwargs)
 
-    @models.permalink
     def get_absolute_url(self):
         """
         Builds and returns the entry's URL based on
@@ -176,11 +176,12 @@ class CoreEntry(models.Model):
         publication_date = self.publication_date
         if timezone.is_aware(publication_date):
             publication_date = timezone.localtime(publication_date)
-        return ('zinnia:entry_detail', (), {
+        return reverse('zinnia:entry_detail', kwargs={
             'year': publication_date.strftime('%Y'),
             'month': publication_date.strftime('%m'),
             'day': publication_date.strftime('%d'),
-            'slug': self.slug})
+            'slug': self.slug
+        })
 
     def __str__(self):
         return '%s: %s' % (self.title, self.get_status_display())


### PR DESCRIPTION
Replaced all instances of the deprecated `models.permalink` wrapper with direct `reverse()` usage in `helpdesk/models.py`. 
Didn't change `@models.permalink` decorator in `Zinnia` module for now
