### PR TITLE
#108 added on-delete-params on one-to-one relationships

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1171,7 +1171,7 @@ class UserSettings(models.Model):
     We should always refer to user.usersettings.settings['setting_name'].
     """
 
-    user = models.OneToOneField(settings.AUTH_USER_MODEL)
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
 
     settings_pickled = models.TextField(
         _('Settings Dictionary'),

--- a/payments/models.py
+++ b/payments/models.py
@@ -150,7 +150,7 @@ class PriceSlab(models.Model):
 
 class Subscription(models.Model):
     """Model representing a company's subscription to a pricing plan."""
-    company = models.OneToOneField(Company, null=True, blank=True, default=None)
+    company = models.OneToOneField(Company, null=True, blank=True, default=None, on_delete=models.CASCADE)
     expiry = models.DateTimeField(null=True, blank=True, default=None)
     added_users = models.PositiveIntegerField(null=True, blank=True, default=0)
     price_slab = models.ForeignKey(PriceSlab, null=True, blank=True, default=None,on_delete=models.SET_NULL)


### PR DESCRIPTION
#108 

## Description
This PR adds the required `on_delete` parameter to OneToOneField relationships that were missing it. This is a required parameter in Django to specify what happens to the related object when the referenced object is deleted.

## Changes Made
1. In `payments/models.py`:
   - Added `on_delete=models.CASCADE` to `Subscription.company` field
   - This ensures that when a company is deleted, its subscription is also deleted

2. In `helpdesk/models.py`:
   - Added `on_delete=models.CASCADE` to `UserSettings.user` field
   - This ensures that when a user is deleted, their settings are also deleted

- The CASCADE behavior was chosen because:
  - For subscriptions: If a company is deleted, there's no reason to keep their subscription data
  - For user settings: If a user is deleted, their settings should be deleted as they are user-specific


- All other OneToOneField relationships in the codebase already had appropriate `on_delete` parameters