### PR TITLE
[chore] Replace package manager from PyPI to UV (#99)

### DIFF
--- a/Process to setup UV and Install modules.txt
+++ b/Process to setup UV and Install modules.txt
@@ -1,0 +1,97 @@
+Process to setup UV and Install modules according to UV.
+
+Step0:	Sync the repository in develop.
+
+Step1:	Cloning the Repository
+	- git clone https://github.com/SaiBhaskar0987/SpotAxis.git
+
+Step2:	Step into the Spotaxis folder
+	- cd SpotAxis
+	(check that pyproject.toml should be there)
+
+Step3: 	Changing my branch from master to develop
+	- git checkout develop
+	- git branch
+
+Step4: 	Creating your own branch
+	- git checkout -b branch name
+
+(I choose try in powershell from this step, Open VScode and open SpotAxis folder.)
+Step4: 	Making new virtual environment(.uvenu) in SpoxAxis
+	- python3 -m venv .uvenu
+	(.uvenu is my new virtual environment name, you can keep your own)
+
+Step5: 	Activating Environment
+	Git Bash:
+		- source .uvenu/Scripts/activate
+
+	Powershell (VScode-Terminal):
+		- .uvenu\Scripts\Activate.ps1
+Step6: 	Install UV
+	- pip install uv
+	(Check that uv should be installed in your new virtual environment)
+	-pip list
+
+step7: 	Install all the modules from pyproject.toml
+	- uv pip install -e .
+
+Done with UV and you will get rid of all import errors. Thank you
+
+
+
+
+Questions:(For getting understanding about UV)
+
+
+1. What is UV?
+Ans:
+UV is a tool that helps us install Python packages (little pieces of code made by other people that we can use in our own programs).
+	👉 Think of UV like a super-fast robot helper that brings you the tools you need to build your Python projects.
+	📦 For example: If your code wants to make a chart, UV will go and fetch a package called matplotlib that helps make charts.
+
+2. Explain UV in depth?
+Ans:
+UV is:
+	⚡ Very fast – It uses a language called Rust which makes it super speedy.
+	🧠 Smart – It solves complicated dependency puzzles (figuring out which versions of packages can work together).
+	📦 A package manager – Just like pip, but better in many ways.
+	🌱 Built to be modern – It works really well with new Python projects and pyproject.toml.
+	📘 Example: If your pyproject.toml says you need Django, UV will find the best version and install it very quickly in your 	environment.
+
+3. Why UV Setup is Required?
+Ans:
+We set up UV to:
+	✅ Use the new pyproject.toml format easily.
+	🚀 Speed up the setup of big projects.
+	💼 Work better with modern tools and virtual environments.
+	🧰 Help keep all needed packages organized inside a clean space (like a toolbox).
+	🧪 Example: You start a new project called “MyCoolApp.” You use UV to quickly install all the tools your app needs.
+
+4. Why are we using UV, when we already have pip?
+Ans:
+Yes, we have pip, but:
+		pip					uv
+	📦 Good					⚡ Faster and smarter
+	🐢 Slower in big projects		🚀 Much faster
+	   Works well				   Works better with modern setups
+	   Needs manual fixes sometimes	           Auto-fixes lots of problems
+
+🏁 Example: It’s like using a bicycle (pip) 🚲 vs. a racing car (uv) 🏎️!
+	Using pip:
+ 	 - pip install -r requirements.txt
+	Using uv (much faster!):
+ 	 - uv pip install -r requirements.txt
+
+
+5. What is the difference between UV and PIP?
+
+| Feature                    | pip                | uv                 |
+| -------------------------- | ------------------ | ------------------ |
+| Speed                      | Slower             | Much faster ⚡     |
+| Language                   | Python             | Rust (super-fast)  |
+| Handles pyproject.toml     | Not directly       | Yes, very well ✅  |
+| Solves tricky dependencies | Not always         | Yes, very smart 🧠 |
+| Modern?                    | Old but still used | New and modern 🚀  |
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,73 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "spotaxis"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "autodoc>=0.5.0",
+    "beautifulsoup4>=4.13.4",
+    "datefinder>=0.7.3",
+    "django>=5.2.1",
+    "django-contrib-comments>=2.2.0",
+    "django-filter>=25.1",
+    "django-mptt>=0.17.0",
+    "django-nested-formset>=0.1.4",
+    "django-tagging>=0.5.0",
+    "django-xmlrpc>=0.1.8",
+    "djangorestframework>=3.16.0",
+    "docutils>=0.21.2",
+    "email-reply-parser>=0.5.12",
+    "hashids>=1.3.1",
+    "ipgetter2>=1.1.10",
+    "mammoth>=1.9.1",
+    "markdown>=3.8",
+    "mots-vides>=2015.5.11",
+    "oauth2>=1.9.0.post1",
+    "paypalrestsdk>=1.13.3",
+    "pdfminer-six>=20250506",
+    "pillow>=11.2.1",
+    "pymysql>=1.1.1",
+    "pypdf>=5.5.0",
+    "pyth>=0.6.0",
+    "python-dateutil>=2.9.0.post0",
+    "python-docx>=1.1.2",
+    "python-linkedin>=4.1",
+    "requests>=2.32.3",
+    "requests-oauthlib>=2.0.0",
+    "selenium>=4.33.0",
+    "six>=1.17.0",
+    "south>=1.0.2",
+    "stop-words>=2018.7.23",
+    "textile>=4.0.3",
+    "unidecode>=1.4.0",
+    "weasyprint>=65.1",
+    "xvfbwrapper>=0.2.13"
+]
+
+[tool.setuptools]
+packages = [
+    "trm",
+    "activities",
+    "candidates",
+    "ckeditor",
+    "common",
+    "companies",
+    "customField",
+    "el_pagination",
+    "example",
+    "helpdesk",
+    "locale",
+    "payments",
+    "resume_parser",
+    "scheduler",
+    "socialmultishare",
+    "ssl",
+    "upload_logos",
+    "zinnia",
+    "vacancies"
+]


### PR DESCRIPTION
Replaced the Python package manager from pip (PyPI) with `uv` for faster and modern dependency management. Removed the old `requirements.txt` dependency system and switched to a `pyproject.toml`-based workflow using UV. Created a `.md` document outlining the complete setup process and environment initialization using `.uvenu`.
To improve package installation speed, handle modern `pyproject.toml` dependencies, and streamline project environment management.
Closes #99

## Checklist
- [x] Documented setup steps in `Process to setup UV and Install modules.txt`
- [x] Rebased with `main`
- [x] Commits are logically split