### PR TITLE
[docs] Add module-level docstrings in Zinnia Module (#29)

### DIFF
--- a/zinnia/api/serializers.py
+++ b/zinnia/api/serializers.py
@@ -12,6 +12,13 @@ from customField.api.serializers import FieldSerializer
 
 
 class AuthorSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Author model (uses the custom user model).
+
+    Adds calculated fields:
+    - entries_count: Total entries written by the author.
+    - published_entries_count: Total published entries by the author.
+    """
     entries_count = serializers.SerializerMethodField()
     published_entries_count = serializers.SerializerMethodField()
 
@@ -24,13 +31,20 @@ class AuthorSerializer(serializers.ModelSerializer):
         read_only_fields = ['id', 'entries_count', 'published_entries_count', 'get_absolute_url']
 
     def get_entries_count(self, obj):
+        """
+        Returns the total number of entries by the author.
+        """
         return obj.entries.count()
 
     def get_published_entries_count(self, obj):
+        """
+        Returns the number of published entries by the author.
+        """
         return obj.entries.filter(status=PUBLISHED).count()
 
 
 class CategorySerializer(serializers.ModelSerializer):
+    """Serializer for the Category model."""
     parent = serializers.PrimaryKeyRelatedField(
         queryset=Category.objects.all(),
         required=False,
@@ -54,12 +68,21 @@ class CategorySerializer(serializers.ModelSerializer):
         ]
 
     def get_entries_count(self, obj):
+        """
+        Returns the total number of entries in this category.
+        """
         return obj.entries.count()
 
     def get_published_entries_count(self, obj):
+        """
+        Returns the number of published entries in this category.
+        """
         return obj.entries.filter(status=PUBLISHED).count()
 
     def get_children(self, obj):
+        """
+        Returns the serialized child categories for this category.
+        """
         children = obj.get_children()
         if children:
             return CategorySerializer(children, many=True).data
@@ -67,6 +90,7 @@ class CategorySerializer(serializers.ModelSerializer):
 
 
 class EntrySerializer(serializers.ModelSerializer):
+    """Serializer for the Entry model (blog post)."""
     authors = AuthorSerializer(many=True, read_only=True)
     categories = CategorySerializer(many=True, read_only=True)
     sites = serializers.PrimaryKeyRelatedField(

--- a/zinnia/calendar.py
+++ b/zinnia/calendar.py
@@ -1,6 +1,5 @@
 """Calendar module for Zinnia"""
 
-
 from __future__ import absolute_import
 from .calendar import HTMLCalendar
 from datetime import date

--- a/zinnia/comparison.py
+++ b/zinnia/comparison.py
@@ -17,7 +17,6 @@ from zinnia.settings import STOP_WORDS
 from six.moves import map
 from six.moves import range
 
-
 PUNCTUATION = re.compile(r'\p{P}+')
 
 

--- a/zinnia/migrations/0001_initial.py
+++ b/zinnia/migrations/0001_initial.py
@@ -12,7 +12,7 @@ import zinnia.settings
 
 
 class Migration(migrations.Migration):
-
+    """Creates initial models for the Zinnia application, including Category, Entry, and Author, with their fields, relationships, and options."""
     dependencies = [
         ('auth', '0001_initial'),
         ('sites', '0001_initial'),

--- a/zinnia/migrations/0002_lead_paragraph_and_image_caption.py
+++ b/zinnia/migrations/0002_lead_paragraph_and_image_caption.py
@@ -4,7 +4,7 @@ from django.db import models
 
 
 class Migration(migrations.Migration):
-
+    """Adds image_caption and lead text fields to the Entry model in the Zinnia application."""
     dependencies = [
         ('zinnia', '0001_initial'),
     ]

--- a/zinnia/migrations/0003_publication_date.py
+++ b/zinnia/migrations/0003_publication_date.py
@@ -16,7 +16,7 @@ def unfill_publication_date(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
+    """Handles migration for the Entry model by adding publication_date, updating metadata, and setting initial values from creation_date."""
     dependencies = [
         ('zinnia', '0002_lead_paragraph_and_image_caption'),
     ]

--- a/zinnia/migrations/0004_on_delete_arg.py
+++ b/zinnia/migrations/0004_on_delete_arg.py
@@ -5,7 +5,9 @@ import mptt.fields
 
 
 class Migration(migrations.Migration):
-
+    """
+    Alters the 'parent' field in the 'Category' model to support MPTT-based hierarchy.
+    """
     dependencies = [
         ('zinnia', '0003_publication_date'),
     ]

--- a/zinnia/tests/test_category.py
+++ b/zinnia/tests/test_category.py
@@ -10,7 +10,9 @@ from zinnia.signals import disconnect_entry_signals
 
 
 class CategoryTestCase(TestCase):
-
+    """
+    Test suite for validating behavior of Zinnia Category model.
+    """
     def setUp(self):
         disconnect_entry_signals()
         self.site = Site.objects.get_current()

--- a/zinnia/tests/test_managers.py
+++ b/zinnia/tests/test_managers.py
@@ -18,7 +18,7 @@ from zinnia.tests.utils import skip_if_custom_user
 
 @skip_if_custom_user
 class ManagersTestCase(TestCase):
-
+    """Test case for validating the behavior of custom managers in Zinnia's models."""
     def setUp(self):
         disconnect_entry_signals()
         self.sites = [

--- a/zinnia/tests/test_markups.py
+++ b/zinnia/tests/test_markups.py
@@ -19,6 +19,12 @@ from zinnia.tests.utils import is_lib_available
 
 
 class MarkupsTestCase(TestCase):
+    """
+    Tests markup rendering using Textile, Markdown, and reStructuredText.
+
+    Verifies proper HTML conversion of sample content and 
+    checks Markdown extension behavior.
+    """
     text = 'Hello *World* !'
 
     @skipUnless(is_lib_available('textile'), 'Textile is not available')
@@ -75,7 +81,14 @@ class MarkupsTestCase(TestCase):
 
 @skipUnless(sys.version_info >= (2, 7, 0),
             'Cannot run these tests under Python 2.7')
+
 class MarkupFailImportTestCase(TestCase):
+    """
+    Tests fallback behavior when markup libraries are not installed.
+
+    Simulates import failures and checks that the original content is returned
+    with appropriate runtime warnings.
+    """
     exclude_list = ['textile', 'markdown', 'docutils']
 
     def setUp(self):
@@ -123,7 +136,12 @@ class MarkupFailImportTestCase(TestCase):
 
 
 class HtmlFormatTestCase(TestCase):
+    """
+    Tests the html_format utility with different markup configurations.
 
+    Ensures correct HTML output or fallback behavior based on the 
+    current MARKUP_LANGUAGE setting.
+    """
     def setUp(self):
         self.original_rendering = markups.MARKUP_LANGUAGE
 

--- a/zinnia/tests/test_models_bases.py
+++ b/zinnia/tests/test_models_bases.py
@@ -8,7 +8,7 @@ from zinnia.models_bases.entry import AbstractEntry
 
 
 class LoadModelClassTestCase(TestCase):
-
+    """Tests dynamic model class importing via load_model_class."""
     def test_load_model_class(self):
         self.assertEqual(
             load_model_class('zinnia.models_bases.entry.AbstractEntry'),

--- a/zinnia/tests/test_ping.py
+++ b/zinnia/tests/test_ping.py
@@ -19,15 +19,18 @@ from zinnia.signals import disconnect_entry_signals
 
 
 class NoThreadMixin(object):
+    """Runs threaded pingers in a non-threaded, synchronous mode for testing."""
     def start(self):
         self.run()
 
 
 class NoThreadDirectoryPinger(NoThreadMixin, DirectoryPinger):
+    """Non-threaded version of DirectoryPinger for test cases."""
     pass
 
 
 class NoThreadExternalUrlsPinger(NoThreadMixin, ExternalUrlsPinger):
+    """Non-threaded version of ExternalUrlsPinger for test cases."""
     pass
 
 

--- a/zinnia/tests/test_preview.py
+++ b/zinnia/tests/test_preview.py
@@ -7,7 +7,7 @@ from zinnia.preview import HTMLPreview
 
 
 class HTMLPreviewTestCase(TestCase):
-
+    """TestCase class for validating the functionality of the HTMLPreview class."""
     def test_splitters(self):
         text = '<p>Hello World</p><!-- more --><p>Hello dude</p>'
         preview = HTMLPreview(text, splitters=['<!--more-->'],


### PR DESCRIPTION
This PR adds comprehensive module-level docstrings of the Zinnia module.
To improve code readability, maintainability, and support automated documentation generation as part of Issue #29.
Closes #29