### PR TITLE
Fixed issues on emails (Closes #249)

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -109,8 +109,8 @@ def send_TRM_email(subject_template_name, email_template_name, context_email, to
         # print(text_email)
         if not from_email:
             from_email = DEFAULT_FROM_EMAIL
-        html_email.encoding = "utf-8"
-        if isinstance(to_user, types.StringTypes):
+        # html_email.encoding = "utf-8"
+        if isinstance(to_user, str):
             to_user = [to_user]
         to_user = list(to_user)
         # try:

--- a/companies/views.py
+++ b/companies/views.py
@@ -11,8 +11,8 @@ from activities.utils import *
 from activities.models import *
 from candidates.models import Candidate, Academic, CV_Language, Curriculum, Academic_Area, Expertise, Training, Certificate, Project
 from common import registration_settings
-from common.forms import AdressForm, UserDataForm, BasicUserDataForm, send_TRM_email, UserPhotoForm, SubdomainForm
-from common.models import Profile, Country, send_email_to_TRM, Gender, Subdomain
+from common.forms import AdressForm, UserDataForm, BasicUserDataForm, UserPhotoForm, SubdomainForm
+from common.models import Profile, Country, send_email_to_TRM, Gender, Subdomain, send_TRM_email
 from companies.forms import CompanyForm, SearchCvForm, CompanyLogoForm, MemberInviteForm
 from companies.models import Company_Industry, Recommendations, Recommendation_Status, Company, Wallet, Recruiter, Stage, RecruiterInvitation, ExternalReferal
 from customField.forms import TemplateForm, FieldFormset


### PR DESCRIPTION
Issue #249

- Emails weren't being sent due to deprecated implementation.
- Bought implementation up to spec.
- Additionally, a few methods in the module `companies/views` were calling the method `send_TRM_email` but the method was being imported from the wrong module.
- Corrected the import.