### PR TITLE
[Bug] Resolve CKEditor browse view errors for static tag and context usage (Closes #244)

### DIFF
--- a/ckeditor/templates/browse.html
+++ b/ckeditor/templates/browse.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <meta http-equiv="Content-type" content="text/html; charset=utf-8">

--- a/ckeditor/views.py
+++ b/ckeditor/views.py
@@ -216,8 +216,8 @@ def browse(request):
 
     Passes a list of image files and their URLs in the template context.
     """
-    context = RequestContext(request, {
+    context = {
         'files': get_files_browse_urls(request.user),
-    })
+    }
     return render(request,'browse.html', context)
     


### PR DESCRIPTION
Closes #244

Checkpoints:

- Replaced deprecated {% load staticfiles %} with {% load static %} in browse.html

- Removed usage of RequestContext and passed plain dict to render() in ckeditor.views.browse