### PR TITLE
[Error] Fix 404 on /resources/comments/ by redirecting GET requests to /posted/ (Closes #223)

### DIFF
--- a/TRM/subdomain_urls.py
+++ b/TRM/subdomain_urls.py
@@ -23,6 +23,8 @@ from django.urls import reverse_lazy
 from TRM import settings
 # from django.views.generic.simple import direct_to_template
 from companies.views import upload_vacancy_file, delete_vacancy_file
+from django.shortcuts import redirect
+
 
 admin.autodiscover()
 handler500 = 'TRM.views.handler500'
@@ -43,6 +45,7 @@ urlpatterns = [
     path('contact/',  TRM_views.contact, name="contact"),
     path('comingsoon/',  TRM_views.comingsoon, name="comingsoon"),
     path('jobs/',  TRM_views.job_board, name="job_board"),
+    path('resources/comments/', lambda request: redirect('/resources/comments/posted/') if request.method == 'GET' else None),
     path('resources/comments/', include('django_comments.urls')),
     # url(r'resources/', include('zinnia.urls')),
     # url(r'help/', include('helpdesk.urls')),


### PR DESCRIPTION
Closes #223

Checkpoints:

- Added a redirect for GET requests to /resources/comments/ so it no longer returns a 404 error.
- Now, visiting /resources/comments/ via GET will redirect to /resources/comments/posted/, which is a valid endpoint.
- Included the redirect before the include('django_comments.urls') line to avoid conflict.
- No changes were made to comment logic or POST behavior.