### PR TITLE
Fixed login issue on subdomain

### DIFF
--- a/TRM/subdomain_urls.py
+++ b/TRM/subdomain_urls.py
@@ -82,12 +82,12 @@ urlpatterns = [
     #     'template_name': 'password_change.html',
     #     'password_change_form': ChangePasswordForm},
     #    name='auth_password_change'),
-    #path('password/reset/', django_auth_views.password_reset,
-    #    {'password_reset_form': CustomPasswordResetForm,
-    #     'template_name': 'password_reset.html',
-    #     'email_template_name': 'mails/password_reset_email.html',
-    #     'subject_template_name': 'mails/password_reset_subject.html', },
-    #    name='auth_password_reset'),
+    path('password/reset/', django_auth_views.PasswordResetView.as_view(),
+        {'password_reset_form': CustomPasswordResetForm,
+            'template_name': 'password_reset.html',
+            'email_template_name': 'mails/password_reset_email.html',
+            'subject_template_name': 'mails/password_reset_subject.html', },
+        name='auth_password_reset'),
     #path('password/reset/<uidb64>[0-9A-Za-z]+>-<token>.+/',
     #    django_auth_views.password_reset_confirm,
     #    {'template_name': 'password_reset_confirm.html',
@@ -117,7 +117,7 @@ urlpatterns = [
             template_name='password_reset_confirm.html',
             success_url='custom_password_reset_complete',
         ),
-        name='auth_password_reset_confirm'
+        name='password_reset_confirm'
     ),
 
     path(


### PR DESCRIPTION
- Issue #
- `login.html` was expecting url named `auth_password_reset` for password recovery but it was commented out
- uncommented the url and made sure it matched the current spec for django auth views
- additionally, changed the url name of `password/reset/<uidb64>/<token>/` from `auth_password_reset_confirm` to `password_reset_confirm` to match the expected url name in the template.