### PR TITLE
Increased maximum phone number length to 16 digits in CandidateContactForm and CompanyForm (Closes #267)

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -232,7 +232,7 @@ class CandidateContactForm(forms.ModelForm):
     )
     phone = PNF(
         min_length=10,
-        max_length=12,
+        max_length=16,
         error_messages={
             'invalid': _("Enter a valid 10 digit phone"),
             'min_length': _("Enter a valid 10 digit phone"),
@@ -243,7 +243,7 @@ class CandidateContactForm(forms.ModelForm):
     )
     cellphone = PNF(
         min_length=10,
-        max_length=12,
+        max_length=16,
         error_messages={
             'invalid': _("Enter a valid 10 digit mobile phone"),
             'min_length': _("Enter a valid 10 digit mobile phone"),
@@ -1084,7 +1084,7 @@ class CandidateMiniForm(forms.ModelForm):
     )
     phone = PNF(
         min_length=10,
-        max_length=12,
+        max_length=16,
         error_messages={
             'invalid': _("Enter a valid 10 digit phone"),
             'min_length': _("Enter a valid 10 digit phone"),

--- a/companies/forms.py
+++ b/companies/forms.py
@@ -168,7 +168,7 @@ class CompanyForm(forms.ModelForm):
         },
     )
     phone = PNF(
-        max_length=12,
+        max_length=16,
         min_length=10,
         error_messages={
             'invalid': _("Enter a valid 10 dg=igit phone"),


### PR DESCRIPTION
- Issue #267
- Increased max phone number length to 16
- Did not adjust the minimum limit, could be lowered if needed