### PR TITLE
resolve 292 issue of careersite for refusing to connect issue

### DIFF
--- a/TRM/settings.py
+++ b/TRM/settings.py
@@ -253,3 +253,4 @@ SITE_SUFFIX = os.getenv('site_suffix', '.spotaxis.com/')
 logo_email = os.getenv('logo_email')
 NOTIFICATION_EMAILS = os.getenv('notification_emails')
 CKEDITOR_UPLOAD_PATH = "uploads/"
+X_FRAME_OPTIONS = 'SAMEORIGIN'


### PR DESCRIPTION
resolved #292 

- Added a line in settings.py at line no.256.
- It is now not showing "refuse to connect".
- In careersite edit button is active and working fine.